### PR TITLE
restore a minimal API token init script according to public articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ See https://api.ovh.com/createToken/ and fill in `ovh.conf` with data received (
 
 In the same directory as ovh.conf, run:
 
-$ python ovhdns.py /domain/zone/example.com
+$ python ovhdns.py /domain/zone/_acme-challenge.example.com
 
 This will prompt you with an URL where you will need to input your OVH account and password to enable the API token. 
 
 The optional string given as parameter defines the Read-Write access granted to the token. /domain gives access to all DNS domains under this OVN account.
-You can use /domain/zone/example.com to limit it to your example.com domain.
+You can use /domain/zone/_acme-challenge.example.com to limit it to your example.com domain.
 If no parameters are given, the script defaults to /domain (BE SURE THIS IS OK FOR YOUR USECASE.)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ It's is inspired (a lot) from the work of https://ungeek.fr/letsencrypt-api-ovh/
 
 See https://api.ovh.com/createToken/ and fill in `ovh.conf` with data received (copy it from demo sample before)
 
+2) Validate the API token and set its capacities
+
+In the same directory as ovh.conf, run:
+
+$ python ovhdns.py /domain/example.com
+
+This will prompt you with an URL where you will need to input your OVH account and password to enable the API token. 
+
+The optional string given as parameter defines the Read-Write access granted to the token. /domain gives access to all DNS domains under this OVN account.
+You can use /domain/example.com to limit it to your example.com domain.
+If no parameters are given, the script defaults to /domain (BE SURE THIS IS OK FOR YOUR USECASE.)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,20 @@ The optional string given as parameter defines the Read-Write access granted to 
 You can use /domain/zone/_acme-challenge.example.com to limit it to your example.com domain.
 If no parameters are given, the script defaults to /domain (BE SURE THIS IS OK FOR YOUR USECASE.)
 
+By default the manual-auth-hook.py script will wait for 120 seconds before allowing ACME to perform the dns challenge, this is to allow for the record to be propagated. Please lower your TTL to low enough values that the validation will not fail due no DNS caching. Don't hesitate to modify the ending "sleep(120)" line to increase the time to be well over your DNS TTL.
+
 ## Usage
 
 Check certbot docs for it but you will need at least the following params:
 
 ```
 --manual --manual-auth-hook ./manual-auth-hook.py --manual-cleanup-hook ./manual-cleanup-hook.py
+
+```
+
+Most people would be ok with:
+
+```
+certbot certonly -d example.com --preferred-challenges dns --manual --manual-auth-hook ./manual-auth-hook.py --manual-cleanup-hook ./manual-cleanup-hook.py
 
 ```

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ See https://api.ovh.com/createToken/ and fill in `ovh.conf` with data received (
 
 In the same directory as ovh.conf, run:
 
-$ python ovhdns.py /domain/example.com
+$ python ovhdns.py /domain/zone/example.com
 
 This will prompt you with an URL where you will need to input your OVH account and password to enable the API token. 
 
 The optional string given as parameter defines the Read-Write access granted to the token. /domain gives access to all DNS domains under this OVN account.
-You can use /domain/example.com to limit it to your example.com domain.
+You can use /domain/zone/example.com to limit it to your example.com domain.
 If no parameters are given, the script defaults to /domain (BE SURE THIS IS OK FOR YOUR USECASE.)
 
 ## Usage

--- a/manual-auth-hook.py
+++ b/manual-auth-hook.py
@@ -30,4 +30,6 @@ id_record = client.post('/domain/zone/%s/record' % basedomain,
                         target=token)
 print (str(id_record["id"]))
 client.post('/domain/zone/%s/refresh' % basedomain)
-time.sleep(5)
+# This is needed to allow for enough time to let the record propagate
+# Don't hesitate to manually increase this value to be well over your record TTL
+time.sleep(120)

--- a/ovhdns.py
+++ b/ovhdns.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-import ovh
+import ovh,sys
 
 # create a client using configuration
 client = ovh.Client()

--- a/ovhdns.py
+++ b/ovhdns.py
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+
+import ovh
+
+# create a client using configuration
+client = ovh.Client()
+
+# Request RW, /domain API access
+ck = client.new_consumer_key_request()
+# If the user asked for a specific API access pattern, use it
+if len(sys.argv) == 2:
+  ck.add_recursive_rules(ovh.API_READ_WRITE, sys.argv[1])
+# or default to give access to all domains (ew.)
+else:
+  ck.add_recursive_rules(ovh.API_READ_WRITE, "/domain")
+
+# Request token
+validation = ck.request()
+
+print "Please visit %s to authenticate" % validation['validationUrl']
+raw_input("and press Enter to continue...")
+
+print "Btw, your 'consumerKey' is '%s'" % validation['consumerKey']
+


### PR DESCRIPTION
Yo, this is the fastest PR of my entire life, so please test it properly before merging it anywhere.

It should make your blogpost ( https://ungeek.fr/letsencrypt-api-ovh/ ) and its derivatives ( http://matthieukeller.com/2016/12/lets-encrypt-certificate-for-offline-servers-with-ovh-dns.html ) correct again, so that people do not need to go through the documentations and examples as I had to :)

It was not the end of the world, but it's better if other people after me don't need to understand all the logic, and can just reuse the python script ;)

I updated the README.md too, as you will read the script defaults to requesting RW on /domain which is probably excessive, but would work 100% of the time for newbies.
An argument could be fed to the script to limit it further.

I'll probably study closer what exact permissions are needed for certbot operations, so I can improve the script to anly request the exact correct operations on a specified domain name.

I am aware that this breaks the --init part of your documentation, but I think it's for the better.

Again, sorry to rush this, I'm running against the clock to meet a deadline, and wanted to do this PR before I had the chance to forget :D 

Thanks for saving my ass with this tool <3