### PR TITLE
Add missing --preferred-challenge in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ See https://api.ovh.com/createToken/ and fill in `ovh.conf` with data received (
 Check certbot docs for it but you will need at least the following params:
 
 ```
---manual --manual-auth-hook ./manual-auth-hook.py --manual-cleanup-hook ./manual-cleanup-hook.py
+--preferred-challenge dns --manual --manual-auth-hook ./manual-auth-hook.py --manual-cleanup-hook ./manual-cleanup-hook.py
 
 ```


### PR DESCRIPTION
Specify the preferred challenge seems required to me.
Without that, the client will try with other challenges, won't it ?