### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ See https://api.ovh.com/createToken/ and fill in `ovh.conf` with data received (
 Check certbot docs for it but you will need at least the following params:
 
 ```
---manual --manual-auth-hook ./manual-auth-hook.py --manual-cleanup-hook ./manual-cleanup-hook.py
+--preferred-challenge dns --manual --manual-auth-hook ./manual-auth-hook.py --manual-cleanup-hook ./manual-cleanup-hook.py
 
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ It's is inspired (a lot) from the work of https://ungeek.fr/letsencrypt-api-ovh/
 
 1) Get OVH API keys
 
-See https://api.ovh.com/createToken/ and fill in `ovh.conf` with data received (copy it from demo sample before)
+See https://api.ovh.com/createToken/ and fill in `ovh.conf` with data received (copy it from demo sample before).  
+
+You can leave the configuration file in the repository directory. But for using the hook scripts outside of the letsencrypt.sh-ovh directory, it could be better to move it to one of the the following locations:
+- `/etc/ovh.conf`
+- `~/.ovh.conf`
 
 
 ## Usage


### PR DESCRIPTION
- Specify the preferred challenge seems required to me.
Without that, the client will try with other challenges, won't it ?
- The ovh.conf file can be put in other locations. With that, it becomes possible to create an alias for certbot with all its arguments and to call it from anywhere.