### PR TITLE
Allow to increase sleep time with an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ Check certbot docs for it but you will need at least the following params:
 --manual --manual-auth-hook ./manual-auth-hook.py --manual-cleanup-hook ./manual-cleanup-hook.py
 
 ```
+
+## Potential issues
+Dns updates can take up to 24 hours to propagate. Actually, in most cases it will take a few seconds.  
+By default, the auth hook waits 10 seconds for the dns update. If this time is insufficient, you can increase it by setting a `CERTBOT_OVH_SLEEPTIME` environment variable with the intended delay:
+```bash
+export CERTBOT_OVH_SLEEPTIME=30
+```

--- a/manual-auth-hook.py
+++ b/manual-auth-hook.py
@@ -30,4 +30,9 @@ id_record = client.post('/domain/zone/%s/record' % basedomain,
                         target=token)
 print (str(id_record["id"]))
 client.post('/domain/zone/%s/refresh' % basedomain)
-time.sleep(10)
+
+if 'CERTBOT_OVH_SLEEPTIME' in os.environ:
+    time.sleep(float(os.environ['CERTBOT_OVH_SLEEPTIME']))
+else:
+    time.sleep(10)
+


### PR DESCRIPTION
10 seconds may be insufficient for dns propagation.